### PR TITLE
adapter-core 3.x.x requires node 16 or newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/iobroker-community-adapters/ioBroker.cleveron"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3"
   },


### PR DESCRIPTION
adapter core 3.x.x. is known to fail whne installed at node 14 or older.
So this adapter must require node 16 or newer.

Please incremengt minotre version number at next release